### PR TITLE
Implement in-line code blocks

### DIFF
--- a/render/bean.go
+++ b/render/bean.go
@@ -208,8 +208,10 @@ func RenderMarkdown(lines []string) string {
 
 				// temporarily replace in-line code block with \x1f (will be restored later to avoid processing Markdown elements within the code block)
 				internalOutput = substrings[1] + "\x1f" + substrings[3]
+
 				// save rendered in-line code block for later restoration
 				renderedCodeBlocks = append(renderedCodeBlocks, "\033[48;5;238;38;5;1m"+substrings[2]+"\033[0m")
+
 				// do not update prevElements since pCode/bold/italic/strikethrough is part of a paragraph (consider it unmatched so that renderParagraph can handle it properly)
 			} else {
 				break
@@ -241,8 +243,8 @@ func RenderMarkdown(lines []string) string {
 		}
 
 		// restore in-line code blocks
-		for _, codeBlock := range renderedCodeBlocks {
-			internalOutput = strings.Replace(internalOutput, "\x1f", codeBlock, 1)
+		for i := len(renderedCodeBlocks) - 1; i >= 0; i-- {
+			internalOutput = strings.Replace(internalOutput, "\x1f", renderedCodeBlocks[i], 1)
 		}
 
 		// match mutually exclusive elements that may NOT be embedded within a paragraph

--- a/render/bean.go
+++ b/render/bean.go
@@ -157,6 +157,8 @@ func RenderMarkdown(lines []string) string {
 	// REGEX DICTIONARY
 	// level 1-6 header (1)
 	header := regexp.MustCompile(`^\s*(#{1,6}) (.*)`)
+	// in-line code (paragraph code) (0)
+	pCode := regexp.MustCompile("^(.*)`(.+?)`(.*)")
 	// bold text (0)
 	bold := regexp.MustCompile(`^(.*)(\*\*.+?\*\*|__.+?__)(.*)`)
 	// italic text (0)
@@ -200,10 +202,18 @@ func RenderMarkdown(lines []string) string {
 
 		// match elements that may be embedded within a paragraph
 		for {
+			if pCode.MatchString(internalOutput) { // bold must be rendered first to avoid matching as italic
+				substrings := pCode.FindStringSubmatch(internalOutput)
+				internalOutput = substrings[1] + "\033[48;5;238;38;5;1m" + substrings[2] + "\033[0m" + substrings[3]
+				// do not update prevElements since pCode/bold/italic/strikethrough is part of a paragraph (consider it unmatched so that renderParagraph can handle it properly)
+			} else {
+				break
+			}
+		}
+		for {
 			if bold.MatchString(internalOutput) { // bold must be rendered first to avoid matching as italic
 				substrings := bold.FindStringSubmatch(internalOutput)
 				internalOutput = substrings[1] + "\033[1m" + substrings[2][2:len(substrings[2])-2] + "\033[0m" + substrings[3]
-				// do not update prevElements since bold/italic/strikethrough is part of a paragraph (consider it unmatched so that renderParagraph can handle it properly)
 			} else {
 				break
 			}

--- a/test/inlineCode_test.go
+++ b/test/inlineCode_test.go
@@ -1,0 +1,60 @@
+package test
+
+import (
+	"testing"
+
+	bean "github.com/Trojan2021/BEAN/render"
+)
+
+func TestInlineCode(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []string
+		expected string
+	}{
+		// Inline Code Testing
+		{
+			name:     "Plain in-line code block",
+			input:    []string{"`code`"},
+			expected: "\033[48;5;238;38;5;1mcode\033[0m ",
+		},
+		{
+			name:     "Plain in-line code block (emphasis within code block)",
+			input:    []string{"`**_~~code~~_**`"},
+			expected: "\033[48;5;238;38;5;1m**_~~code~~_**\033[0m ",
+		},
+		{
+			name:     "Used in a paragraph (single-line)",
+			input:    []string{"Paragraph with `code` in it."},
+			expected: "Paragraph with \033[48;5;238;38;5;1mcode\033[0m in it. ",
+		},
+		{
+			name:     "Used in a paragraph (multi-line)",
+			input:    []string{"Paragraph with", "`code` in it."},
+			expected: "Paragraph with \033[48;5;238;38;5;1mcode\033[0m in it. ",
+		},
+		{
+			name:     "Used in a paragraph (multi-line; all forms of emphasis)",
+			input:    []string{"**Paragraph** _with_ `code` ~~in it~~ `**and such**`.", "Code blocks can be **_~~`emphasized`~~_** externally."},
+			expected: "\033[1mParagraph\033[0m \033[3mwith\033[0m \033[48;5;238;38;5;1mcode\033[0m \033[9min it\033[0m \033[48;5;238;38;5;1m**and such**\033[0m. Code blocks can be \033[1m\033[3m\033[9m\033[48;5;238;38;5;1memphasized\033[0m\033[0m\033[0m\033[0m externally. ",
+		},
+		{
+			name:     "Used in a list",
+			input:    []string{"- List parent", "\t- List child with `code` in it."},
+			expected: "• List parent\n    • List child with \033[48;5;238;38;5;1mcode\033[0m in it.\n",
+		},
+		{
+			name:     "Used in a header",
+			input:    []string{"# Header With `Code` In It"},
+			expected: "\033[1m─Header With \033[48;5;238;38;5;1mCode\033[0m In It─\033[0m\n",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			output := bean.RenderMarkdown(tt.input)
+			if output != tt.expected {
+				bufferFailure(t, output, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This merge adds support for `in-line code blocks` within paragraphs, lists, and headers.

Parsing of in-line code blocks is quite similar to parsing of emphasis elements (bold/italic/strikethrough), with the key difference being that other Markdown elements cannot be rendered within the in-line code blocks.

Because of this, in-line code blocks use a two-step rendering process. First they are detected and replaced with placeholder text (the rendered version is saved to a slice), then after all other paragraph-compatible Markdown elements are rendered, the placeholder text is replaced with the rendered code blocks.