### PR TITLE
Implement text/word wrapping for paragraphs and lists

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,9 @@ module github.com/Trojan2021/BEAN
 
 go 1.23.0
 
-require github.com/mitchellh/go-wordwrap v1.0.1
+require github.com/muesli/reflow v0.3.0
+
+require (
+	github.com/mattn/go-runewidth v0.0.12 // indirect
+	github.com/rivo/uniseg v0.2.0 // indirect
+)

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,9 @@ module github.com/Trojan2021/BEAN
 
 go 1.23.0
 
-require golang.org/x/term v0.25.0
+require (
+	github.com/mitchellh/go-wordwrap v1.0.1
+	golang.org/x/term v0.25.0
+)
 
 require golang.org/x/sys v0.26.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,4 @@ module github.com/Trojan2021/BEAN
 
 go 1.23.0
 
-require (
-	github.com/mitchellh/go-wordwrap v1.0.1
-	golang.org/x/term v0.25.0
-)
-
-require golang.org/x/sys v0.26.0 // indirect
+require github.com/mitchellh/go-wordwrap v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/mitchellh/go-wordwrap v1.0.1 h1:TLuKupo69TCn6TQSyGxwI1EblZZEsQ0vMlAFQflz0v0=
+github.com/mitchellh/go-wordwrap v1.0.1/go.mod h1:R62XHJLzvMFRBbcrT7m7WgmE1eOyTSsCt+hzestvNj0=
 golang.org/x/sys v0.26.0 h1:KHjCJyddX0LoSTb3J+vWpupP9p0oznkqVk/IfjymZbo=
 golang.org/x/sys v0.26.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.25.0 h1:WtHI/ltw4NvSUig5KARz9h521QvRC8RmF/cuYqifU24=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,7 @@
-github.com/mitchellh/go-wordwrap v1.0.1 h1:TLuKupo69TCn6TQSyGxwI1EblZZEsQ0vMlAFQflz0v0=
-github.com/mitchellh/go-wordwrap v1.0.1/go.mod h1:R62XHJLzvMFRBbcrT7m7WgmE1eOyTSsCt+hzestvNj0=
+github.com/mattn/go-runewidth v0.0.12 h1:Y41i/hVW3Pgwr8gV+J23B9YEY0zxjptBuCWEaxmAOow=
+github.com/mattn/go-runewidth v0.0.12/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
+github.com/muesli/reflow v0.3.0 h1:IFsN6K9NfGtjeggFP+68I4chLZV2yIKsXJFNZ+eWh6s=
+github.com/muesli/reflow v0.3.0/go.mod h1:pbwTDkVPibjO2kyvBQRBxTWEEGDGq0FlB1BIKtnHY/8=
+github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
+github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
+github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,2 @@
 github.com/mitchellh/go-wordwrap v1.0.1 h1:TLuKupo69TCn6TQSyGxwI1EblZZEsQ0vMlAFQflz0v0=
 github.com/mitchellh/go-wordwrap v1.0.1/go.mod h1:R62XHJLzvMFRBbcrT7m7WgmE1eOyTSsCt+hzestvNj0=
-golang.org/x/sys v0.26.0 h1:KHjCJyddX0LoSTb3J+vWpupP9p0oznkqVk/IfjymZbo=
-golang.org/x/sys v0.26.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
-golang.org/x/term v0.25.0 h1:WtHI/ltw4NvSUig5KARz9h521QvRC8RmF/cuYqifU24=
-golang.org/x/term v0.25.0/go.mod h1:RPyXicDX+6vLxogjjRxjgD2TKtmAO6NZBsBRfrOLu7M=

--- a/render/bean.go
+++ b/render/bean.go
@@ -115,7 +115,7 @@ func RenderMarkdown(lines []string, terminalWidth int) string {
 	// mergeBuffers merges the contents of pBuffer (word-wrapped) into oBuffer and resets pBuffer.
 	mergeBuffers := func() {
 		if pBuffer.Len() > 0 {
-			oBuffer.WriteString(wrap.String(wordwrap.String(strings.TrimRight(pBuffer.String(), " "), terminalWidth), terminalWidth))
+			oBuffer.WriteString(wrap.String(wordwrap.String(pBuffer.String(), terminalWidth), terminalWidth))
 			pBuffer.Reset()
 		}
 	}

--- a/render/bean.go
+++ b/render/bean.go
@@ -341,14 +341,14 @@ func RenderMarkdown(lines []string, terminalWidth int) string {
 				prevListWasOrdered = true
 			}
 
-			// determine how many new lines to preceed list with
+			// determine how many new lines to precede list with
 			var lineBeginning string
 			if i != 0 {
 				if prevElements[0] == 255 && prevElements[1] == 0 {
-					// preceed the list with two newline characters if it follows a paragraph that is separated by blank lines
+					// precede the list with two newline characters if it follows a paragraph that is separated by blank lines
 					lineBeginning = "\n\n"
 				} else if prevElements[0] == 0 || (prevElements[0] == 255 && prevElements[1] == 10) {
-					// preceed the list with one newline character if it follows another list that is separated by blank lines
+					// precede the list with one newline character if it follows another list that is separated by blank lines
 					// OR if it directly follows a paragraph
 					lineBeginning = "\n"
 				}

--- a/render/bean.go
+++ b/render/bean.go
@@ -349,7 +349,7 @@ func RenderMarkdown(lines []string, terminalWidth int) string {
 			}
 
 			// write the list item with the appropriate indentation
-			internalOutput = lineBeginning + strings.Repeat(" ", indentMultiplier*4) + bullet + substrings[3] + "\n"
+			internalOutput = lineBeginning + strings.ReplaceAll(wrap.String(wordwrap.String(strings.Repeat(" ", indentMultiplier*4)+bullet+substrings[3], terminalWidth), terminalWidth), "\n", "\n  "+strings.Repeat(" ", indentMultiplier*4)) + "\n"
 
 			// supply information for next line iteration
 			prevIndentMultiplier = indentMultiplier

--- a/render/bean.go
+++ b/render/bean.go
@@ -127,17 +127,10 @@ func RenderMarkdown(lines []string) string {
 
 		// determine if following a paragraph
 		// begin line with two newline characters if starting a new paragraph following another paragraph
-		if currentLineTrimmed != "" {
-			if prevElements[0] == 255 && prevElements[1] == 0 {
-				lineBeginning = "\n\n"
-			} else {
-				// do not begin line with newline character if the previous line is part of the current paragraph
-				lineBeginning = ""
-			}
+		if prevElements[0] == 255 && prevElements[1] == 0 {
+			lineBeginning = "\n\n"
 		} else {
 			// do not begin line with newline character if the previous line is part of the current paragraph
-			// (the previous line is not empty)
-			// or if the current line is empty
 			lineBeginning = ""
 		}
 
@@ -148,7 +141,7 @@ func RenderMarkdown(lines []string) string {
 			// if line ends in <br>, write the line with a newline character and strip the <br> tag
 			outputString = lineInProgress[:len(lineInProgress)-4] + "\n"
 		} else {
-			// if line is not empty, write the line with a space at the end (for paragraph formatting)
+			// if line does not contain a manual break, write the line with a space at the end (for paragraph formatting)
 			outputString = lineInProgress + " "
 		}
 

--- a/render/bean.go
+++ b/render/bean.go
@@ -341,11 +341,17 @@ func RenderMarkdown(lines []string, terminalWidth int) string {
 				prevListWasOrdered = true
 			}
 
-			// if the previous line is a paragraph OR if the previous line is blank but the last matched element was not a header
-			// (lists with a gap between them should be treated as separate lists), precede the list item with a newline character
+			// determine how many new lines to preceed list with
 			var lineBeginning string
-			if i != 0 && ((prevElements[0] == 0) || (prevElements[0] == 255 && prevElements[1] != 1)) {
-				lineBeginning = "\n"
+			if i != 0 {
+				if prevElements[0] == 255 && prevElements[1] == 0 {
+					// preceed the list with two newline characters if it follows a paragraph that is separated by blank lines
+					lineBeginning = "\n\n"
+				} else if prevElements[0] == 0 || (prevElements[0] == 255 && prevElements[1] == 10) {
+					// preceed the list with one newline character if it follows another list that is separated by blank lines
+					// OR if it directly follows a paragraph
+					lineBeginning = "\n"
+				}
 			}
 
 			// write the list item with the appropriate indentation

--- a/render/bean.go
+++ b/render/bean.go
@@ -8,7 +8,8 @@ import (
 	"strconv"
 	"strings"
 
-	wrap "github.com/mitchellh/go-wordwrap"
+	"github.com/muesli/reflow/wordwrap"
+	"github.com/muesli/reflow/wrap"
 )
 
 // TODO General:
@@ -114,7 +115,7 @@ func RenderMarkdown(lines []string, terminalWidth int) string {
 	// mergeBuffers merges the contents of pBuffer (word-wrapped) into oBuffer and resets pBuffer.
 	mergeBuffers := func() {
 		if pBuffer.Len() > 0 {
-			oBuffer.WriteString(strings.TrimRight(wrap.WrapString(pBuffer.String(), uint(terminalWidth)), " "))
+			oBuffer.WriteString(wrap.String(wordwrap.String(strings.TrimRight(pBuffer.String(), " "), terminalWidth), terminalWidth))
 			pBuffer.Reset()
 		}
 	}

--- a/render/bean.go
+++ b/render/bean.go
@@ -134,9 +134,13 @@ func RenderMarkdown(lines []string) string {
 			return
 		}
 
-		// begin line with two newline characters if starting a new paragraph following another paragraph
+		// determine if newline characters should be added before the current line
 		if prevElements[0] == 255 && prevElements[1] == 0 {
+			// begin line with two newline characters if starting a new paragraph following another paragraph
 			pBuffer.WriteString("\n\n")
+		} else if prevElements[0] == 10 || (prevElements[0] == 255 && prevElements[1] == 10) {
+			// begin line with a newline character if starting a new paragraph following a list
+			pBuffer.WriteString("\n")
 		}
 
 		if strings.TrimRight(lineInProgress, "  ") != lineInProgress {

--- a/render/bean.go
+++ b/render/bean.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 
+	wrap "github.com/mitchellh/go-wordwrap"
 	"golang.org/x/term"
 )
 
@@ -112,10 +113,10 @@ func RenderMarkdown(lines []string) string {
 		prevListWasOrdered = false
 	}
 
-	// mergeBuffers merges the contents of pBuffer into oBuffer and resets pBuffer.
+	// mergeBuffers merges the contents of pBuffer (word-wrapped) into oBuffer and resets pBuffer.
 	mergeBuffers := func() {
 		if pBuffer.Len() > 0 {
-			oBuffer.WriteString(pBuffer.String())
+			oBuffer.WriteString(wrap.WrapString(pBuffer.String(), uint(width)))
 			pBuffer.Reset()
 		}
 	}

--- a/test/1utilities.go
+++ b/test/1utilities.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 )
 
+var terminalWidth = 80
+
 // bufferFailure adds a literal and an ANSI-interpreted representation of a failed test case to the log buffer.
 func bufferFailure(t *testing.T, got, want string) {
 	divider := strings.Repeat("=", 40)

--- a/test/1utilities.go
+++ b/test/1utilities.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 )
 
+// specify a consistent terminal width for testing
 var terminalWidth = 80
 
 // bufferFailure adds a literal and an ANSI-interpreted representation of a failed test case to the log buffer.

--- a/test/1utilities.go
+++ b/test/1utilities.go
@@ -6,7 +6,7 @@ import (
 )
 
 // specify a consistent terminal width for testing
-var terminalWidth = 80
+const terminalWidth = 80
 
 // bufferFailure adds a literal and an ANSI-interpreted representation of a failed test case to the log buffer.
 func bufferFailure(t *testing.T, got, want string) {

--- a/test/bold_test.go
+++ b/test/bold_test.go
@@ -77,7 +77,7 @@ func TestRenderBoldText(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			output := bean.RenderMarkdown(tt.input)
+			output := bean.RenderMarkdown(tt.input, terminalWidth)
 			if output != tt.expected {
 				bufferFailure(t, output, tt.expected)
 			}

--- a/test/bold_test.go
+++ b/test/bold_test.go
@@ -16,62 +16,62 @@ func TestRenderBoldText(t *testing.T) {
 		{
 			name:     "Bold text using double asterisks",
 			input:    []string{"**bold**"},
-			expected: "\033[1mbold\033[0m ",
+			expected: "\033[1mbold\033[0m",
 		},
 		{
 			name:     "Bold text using double underscores",
 			input:    []string{"__bold__"},
-			expected: "\033[1mbold\033[0m ",
+			expected: "\033[1mbold\033[0m",
 		},
 		// Bold within a sentence
 		{
 			name:     "Bold in the middle of sentence",
 			input:    []string{"A sentence with **bold** in the middle."},
-			expected: "A sentence with \033[1mbold\033[0m in the middle. ",
+			expected: "A sentence with \033[1mbold\033[0m in the middle.",
 		},
 		{
 			name:     "Bold at the start and end of sentence",
 			input:    []string{"**Bold** at the start, and at the **end**"},
-			expected: "\033[1mBold\033[0m at the start, and at the \033[1mend\033[0m ",
+			expected: "\033[1mBold\033[0m at the start, and at the \033[1mend\033[0m",
 		},
 		{
 			name:     "Multiple bold segments in one line (not at start or end)",
 			input:    []string{"This is **bold1**, and this is **bold2** as well."},
-			expected: "This is \033[1mbold1\033[0m, and this is \033[1mbold2\033[0m as well. ",
+			expected: "This is \033[1mbold1\033[0m, and this is \033[1mbold2\033[0m as well.",
 		},
 		// Edge cases
 		{
 			name:     "Bold with incomplete asterisks (should render italics)",
 			input:    []string{"This is *not fully bold** text."},
-			expected: "This is \033[3mnot fully bold\033[0m* text. ",
+			expected: "This is \033[3mnot fully bold\033[0m* text.",
 		},
 		{
 			name:     "Bold with incomplete underscores (should render italics)",
 			input:    []string{"This is _not fully bold__ text."},
-			expected: "This is \033[3mnot fully bold\033[0m_ text. ",
+			expected: "This is \033[3mnot fully bold\033[0m_ text.",
 		},
 		// Nested bold with other formatting (italic/strikethrough)
 		{
 			name:     "Bold nested inside italic",
 			input:    []string{"This is _italic **and bold** inside_."},
-			expected: "This is \033[3mitalic \033[1mand bold\033[0m inside\033[0m. ",
+			expected: "This is \033[3mitalic \033[1mand bold\033[0m inside\033[0m.",
 		},
 		{
 			name:     "Bold nested inside strikethrough",
 			input:    []string{"This is ~~strikethrough **and bold** inside~~."},
-			expected: "This is \033[9mstrikethrough \033[1mand bold\033[0m inside\033[0m. ",
+			expected: "This is \033[9mstrikethrough \033[1mand bold\033[0m inside\033[0m.",
 		},
 		// Bold with special characters
 		{
 			name:     "Bold with special characters",
 			input:    []string{"This is **bold & special <chars>** text."},
-			expected: "This is \033[1mbold & special <chars>\033[0m text. ",
+			expected: "This is \033[1mbold & special <chars>\033[0m text.",
 		},
 		// Bold asterisks and underscores
 		{
 			name:     "Bold asterisks and underscores in one line",
 			input:    []string{"Bold asterisks (*****) and bold underscores (_____) should be possible."},
-			expected: "Bold asterisks (\033[1m*\033[0m) and bold underscores (\033[1m_\033[0m) should be possible. ",
+			expected: "Bold asterisks (\033[1m*\033[0m) and bold underscores (\033[1m_\033[0m) should be possible.",
 		},
 	}
 

--- a/test/header_test.go
+++ b/test/header_test.go
@@ -46,7 +46,7 @@ func TestHeader(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			output := bean.RenderMarkdown(tt.input)
+			output := bean.RenderMarkdown(tt.input, terminalWidth)
 			if output != tt.expected {
 				bufferFailure(t, output, tt.expected)
 			}

--- a/test/hr_test.go
+++ b/test/hr_test.go
@@ -35,7 +35,7 @@ func TestHR(t *testing.T) {
 		{
 			name:     "Mixed HR (should render as paragraph)",
 			input:    []string{"_*-"},
-			expected: "_*- ",
+			expected: "_*-",
 		},
 		{
 			name:     "Overkill hyphen HR",

--- a/test/hr_test.go
+++ b/test/hr_test.go
@@ -1,16 +1,13 @@
 package test
 
 import (
-	"os"
 	"strings"
 	"testing"
 
 	bean "github.com/Trojan2021/BEAN/render"
-	"golang.org/x/term"
 )
 
 func TestHR(t *testing.T) {
-	width, _, _ := term.GetSize(int(os.Stdout.Fd()))
 	tests := []struct {
 		name     string
 		input    []string
@@ -20,17 +17,17 @@ func TestHR(t *testing.T) {
 		{
 			name:     "Hyphen HR",
 			input:    []string{"---"},
-			expected: strings.Repeat("─", width) + "\n\n",
+			expected: strings.Repeat("─", terminalWidth) + "\n\n",
 		},
 		{
 			name:     "Asterisk HR",
 			input:    []string{"***"},
-			expected: strings.Repeat("─", width) + "\n\n",
+			expected: strings.Repeat("─", terminalWidth) + "\n\n",
 		},
 		{
 			name:     "Underscore HR",
 			input:    []string{"___"},
-			expected: strings.Repeat("─", width) + "\n\n",
+			expected: strings.Repeat("─", terminalWidth) + "\n\n",
 		},
 		{
 			name:     "Mixed HR (should render as paragraph)",
@@ -40,22 +37,22 @@ func TestHR(t *testing.T) {
 		{
 			name:     "Overkill hyphen HR",
 			input:    []string{"----------"},
-			expected: strings.Repeat("─", width) + "\n\n",
+			expected: strings.Repeat("─", terminalWidth) + "\n\n",
 		},
 		{
 			name:     "Overkill asterisk HR",
 			input:    []string{"**********"},
-			expected: strings.Repeat("─", width) + "\n\n",
+			expected: strings.Repeat("─", terminalWidth) + "\n\n",
 		},
 		{
 			name:     "Overkill underscore HR",
 			input:    []string{"__________"},
-			expected: strings.Repeat("─", width) + "\n\n",
+			expected: strings.Repeat("─", terminalWidth) + "\n\n",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			output := bean.RenderMarkdown(tt.input)
+			output := bean.RenderMarkdown(tt.input, terminalWidth)
 			if output != tt.expected {
 				bufferFailure(t, output, tt.expected)
 			}

--- a/test/inlineCode_test.go
+++ b/test/inlineCode_test.go
@@ -36,7 +36,7 @@ func TestInlineCode(t *testing.T) {
 		{
 			name:     "Used in a paragraph (multi-line; all forms of emphasis)",
 			input:    []string{"**Paragraph** _with_ `code` ~~in it~~ `**and such**`.", "Code blocks can be **_~~`emphasized`~~_** externally."},
-			expected: "\033[1mParagraph\033[0m \033[3mwith\033[0m \033[48;5;238;38;5;1mcode\033[0m \033[9min it\033[0m \033[48;5;238;38;5;1m**and such**\033[0m. Code blocks can be \033[1m\033[3m\033[9m\033[48;5;238;38;5;1memphasized\033[0m\033[0m\033[0m\033[0m externally.",
+			expected: "\033[1mParagraph\033[0m \033[3mwith\033[0m \033[48;5;238;38;5;1mcode\033[0m \033[9min it\033[0m \033[48;5;238;38;5;1m**and such**\033[0m. Code blocks can be \033[1m\033[3m\033[9m\033[48;5;238;38;5;1memphasized\033[0m\033[0m\033[0m\033[0m\nexternally.",
 		},
 		{
 			name:     "Used in a list",

--- a/test/inlineCode_test.go
+++ b/test/inlineCode_test.go
@@ -51,7 +51,7 @@ func TestInlineCode(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			output := bean.RenderMarkdown(tt.input)
+			output := bean.RenderMarkdown(tt.input, terminalWidth)
 			if output != tt.expected {
 				bufferFailure(t, output, tt.expected)
 			}

--- a/test/inlineCode_test.go
+++ b/test/inlineCode_test.go
@@ -16,27 +16,27 @@ func TestInlineCode(t *testing.T) {
 		{
 			name:     "Plain in-line code block",
 			input:    []string{"`code`"},
-			expected: "\033[48;5;238;38;5;1mcode\033[0m ",
+			expected: "\033[48;5;238;38;5;1mcode\033[0m",
 		},
 		{
 			name:     "Plain in-line code block (emphasis within code block)",
 			input:    []string{"`**_~~code~~_**`"},
-			expected: "\033[48;5;238;38;5;1m**_~~code~~_**\033[0m ",
+			expected: "\033[48;5;238;38;5;1m**_~~code~~_**\033[0m",
 		},
 		{
 			name:     "Used in a paragraph (single-line)",
 			input:    []string{"Paragraph with `code` in it."},
-			expected: "Paragraph with \033[48;5;238;38;5;1mcode\033[0m in it. ",
+			expected: "Paragraph with \033[48;5;238;38;5;1mcode\033[0m in it.",
 		},
 		{
 			name:     "Used in a paragraph (multi-line)",
 			input:    []string{"Paragraph with", "`code` in it."},
-			expected: "Paragraph with \033[48;5;238;38;5;1mcode\033[0m in it. ",
+			expected: "Paragraph with \033[48;5;238;38;5;1mcode\033[0m in it.",
 		},
 		{
 			name:     "Used in a paragraph (multi-line; all forms of emphasis)",
 			input:    []string{"**Paragraph** _with_ `code` ~~in it~~ `**and such**`.", "Code blocks can be **_~~`emphasized`~~_** externally."},
-			expected: "\033[1mParagraph\033[0m \033[3mwith\033[0m \033[48;5;238;38;5;1mcode\033[0m \033[9min it\033[0m \033[48;5;238;38;5;1m**and such**\033[0m. Code blocks can be \033[1m\033[3m\033[9m\033[48;5;238;38;5;1memphasized\033[0m\033[0m\033[0m\033[0m externally. ",
+			expected: "\033[1mParagraph\033[0m \033[3mwith\033[0m \033[48;5;238;38;5;1mcode\033[0m \033[9min it\033[0m \033[48;5;238;38;5;1m**and such**\033[0m. Code blocks can be \033[1m\033[3m\033[9m\033[48;5;238;38;5;1memphasized\033[0m\033[0m\033[0m\033[0m externally.",
 		},
 		{
 			name:     "Used in a list",

--- a/test/italic_test.go
+++ b/test/italic_test.go
@@ -16,51 +16,51 @@ func TestRenderItalicText(t *testing.T) {
 		{
 			name:     "Italic text using single asterisks",
 			input:    []string{"*italic*"},
-			expected: "\033[3mitalic\033[0m ",
+			expected: "\033[3mitalic\033[0m",
 		},
 		{
 			name:     "Italic text using single underscores",
 			input:    []string{"_italic_"},
-			expected: "\033[3mitalic\033[0m ",
+			expected: "\033[3mitalic\033[0m",
 		},
 		// Italic within a sentence
 		{
 			name:     "Italic in the middle of sentence",
 			input:    []string{"A sentence with *italic* in the middle."},
-			expected: "A sentence with \033[3mitalic\033[0m in the middle. ",
+			expected: "A sentence with \033[3mitalic\033[0m in the middle.",
 		},
 		{
 			name:     "Italic at the start and end of sentence",
 			input:    []string{"*Italic* at the start, and at the *end*"},
-			expected: "\033[3mItalic\033[0m at the start, and at the \033[3mend\033[0m ",
+			expected: "\033[3mItalic\033[0m at the start, and at the \033[3mend\033[0m",
 		},
 		{
 			name:     "Multiple italic segments in one line (not at start or end)",
 			input:    []string{"This is *italic1*, and this is *italic2* as well."},
-			expected: "This is \033[3mitalic1\033[0m, and this is \033[3mitalic2\033[0m as well. ",
+			expected: "This is \033[3mitalic1\033[0m, and this is \033[3mitalic2\033[0m as well.",
 		},
 		// Nested italic with other formatting (bold/strikethrough)
 		{
 			name:     "Italic nested inside bold",
 			input:    []string{"This is __bold *and italic* inside__."},
-			expected: "This is \033[1mbold \033[3mand italic\033[0m inside\033[0m. ",
+			expected: "This is \033[1mbold \033[3mand italic\033[0m inside\033[0m.",
 		},
 		{
 			name:     "Italic nested inside strikethrough",
 			input:    []string{"This is ~~strikethrough *and italic* inside~~."},
-			expected: "This is \033[9mstrikethrough \033[3mand italic\033[0m inside\033[0m. ",
+			expected: "This is \033[9mstrikethrough \033[3mand italic\033[0m inside\033[0m.",
 		},
 		// Italic with special characters
 		{
 			name:     "Italic with special characters",
 			input:    []string{"This is *italic & special <chars>* text."},
-			expected: "This is \033[3mitalic & special <chars>\033[0m text. ",
+			expected: "This is \033[3mitalic & special <chars>\033[0m text.",
 		},
 		// Italic asterisks and underscores
 		{
 			name:     "Italic asterisks and underscores in one line",
 			input:    []string{"Italic asterisks (***) and italic underscores (___) should be possible."},
-			expected: "Italic asterisks (\033[3m*\033[0m) and italic underscores (\033[3m_\033[0m) should be possible. ",
+			expected: "Italic asterisks (\033[3m*\033[0m) and italic underscores (\033[3m_\033[0m) should be possible.",
 		},
 	}
 

--- a/test/italic_test.go
+++ b/test/italic_test.go
@@ -66,7 +66,7 @@ func TestRenderItalicText(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			output := bean.RenderMarkdown(tt.input)
+			output := bean.RenderMarkdown(tt.input, terminalWidth)
 			if output != tt.expected {
 				bufferFailure(t, output, tt.expected)
 			}

--- a/test/list_test.go
+++ b/test/list_test.go
@@ -117,7 +117,7 @@ func TestRenderLists(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			output := bean.RenderMarkdown(tt.input)
+			output := bean.RenderMarkdown(tt.input, terminalWidth)
 			if output != tt.expected {
 				bufferFailure(t, output, tt.expected)
 			}

--- a/test/newline_test.go
+++ b/test/newline_test.go
@@ -48,6 +48,21 @@ func TestNewline(t *testing.T) {
 			expected: "This is a happy little paragraph \n• First item\n• Second item\n    • Sub item 1\n• Third item\n",
 		},
 		{
+			name:     "List followed by a paragraph (minimal spacing)",
+			input:    []string{"- First item", "- Second item", "\t- Sub item 1", "- Third item", "This is a happy little paragraph"},
+			expected: "• First item\n• Second item\n    • Sub item 1\n• Third item\n\nThis is a happy little paragraph ",
+		},
+		{
+			name:     "List followed by a paragraph (standard spacing)",
+			input:    []string{"- First item", "- Second item", "\t- Sub item 1", "- Third item", "", "This is a happy little paragraph"},
+			expected: "• First item\n• Second item\n    • Sub item 1\n• Third item\n\nThis is a happy little paragraph ",
+		},
+		{
+			name:     "List followed by a paragraph (exaggerated spacing)",
+			input:    []string{"- First item", "- Second item", "\t- Sub item 1", "- Third item", "", "", "", "", "", "", "", "", "This is a happy little paragraph"},
+			expected: "• First item\n• Second item\n    • Sub item 1\n• Third item\n\nThis is a happy little paragraph ",
+		},
+		{
 			name:     "Multiple HRs",
 			input:    []string{"___", "---", "***", "***", "", "", "", "___"},
 			expected: strings.Repeat("─", width) + "\n\n" + strings.Repeat("─", width) + "\n\n" + strings.Repeat("─", width) + "\n\n" + strings.Repeat("─", width) + "\n\n" + strings.Repeat("─", width) + "\n\n",

--- a/test/newline_test.go
+++ b/test/newline_test.go
@@ -1,16 +1,13 @@
 package test
 
 import (
-	"os"
 	"strings"
 	"testing"
 
 	bean "github.com/Trojan2021/BEAN/render"
-	"golang.org/x/term"
 )
 
 func TestNewline(t *testing.T) {
-	width, _, _ := term.GetSize(int(os.Stdout.Fd()))
 	tests := []struct {
 		name     string
 		input    []string
@@ -65,42 +62,42 @@ func TestNewline(t *testing.T) {
 		{
 			name:     "Multiple HRs",
 			input:    []string{"___", "---", "***", "***", "", "", "", "___"},
-			expected: strings.Repeat("─", width) + "\n\n" + strings.Repeat("─", width) + "\n\n" + strings.Repeat("─", width) + "\n\n" + strings.Repeat("─", width) + "\n\n" + strings.Repeat("─", width) + "\n\n",
+			expected: strings.Repeat("─", terminalWidth) + "\n\n" + strings.Repeat("─", terminalWidth) + "\n\n" + strings.Repeat("─", terminalWidth) + "\n\n" + strings.Repeat("─", terminalWidth) + "\n\n" + strings.Repeat("─", terminalWidth) + "\n\n",
 		},
 		{
 			name:     "HR after paragraph",
 			input:    []string{"This is a paragraph.", "---"},
-			expected: "This is a paragraph.\n\n" + strings.Repeat("─", width) + "\n\n",
+			expected: "This is a paragraph.\n\n" + strings.Repeat("─", terminalWidth) + "\n\n",
 		},
 		{
 			name:     "Paragraph after HR",
 			input:    []string{"---", "This is a paragraph."},
-			expected: strings.Repeat("─", width) + "\n\n" + "This is a paragraph.",
+			expected: strings.Repeat("─", terminalWidth) + "\n\n" + "This is a paragraph.",
 		},
 		{
 			name:     "Paragraph after HR (w/blank lines)",
 			input:    []string{"---", "", "", "This is a paragraph."},
-			expected: strings.Repeat("─", width) + "\n\n" + "This is a paragraph.",
+			expected: strings.Repeat("─", terminalWidth) + "\n\n" + "This is a paragraph.",
 		},
 		{
 			name:     "HR after header",
 			input:    []string{"# Heading 1", "---"},
-			expected: "\033[1m─Heading 1─\033[0m\n\n" + strings.Repeat("─", width) + "\n\n",
+			expected: "\033[1m─Heading 1─\033[0m\n\n" + strings.Repeat("─", terminalWidth) + "\n\n",
 		},
 		{
 			name:     "Header after HR",
 			input:    []string{"---", "# Heading 1"},
-			expected: strings.Repeat("─", width) + "\n\n" + "\033[1m─Heading 1─\033[0m\n",
+			expected: strings.Repeat("─", terminalWidth) + "\n\n" + "\033[1m─Heading 1─\033[0m\n",
 		},
 		{
 			name:     "Header after HR (w/blank lines)",
 			input:    []string{"---", "", "# Heading 1"},
-			expected: strings.Repeat("─", width) + "\n\n" + "\033[1m─Heading 1─\033[0m\n",
+			expected: strings.Repeat("─", terminalWidth) + "\n\n" + "\033[1m─Heading 1─\033[0m\n",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			output := bean.RenderMarkdown(tt.input)
+			output := bean.RenderMarkdown(tt.input, terminalWidth)
 			if output != tt.expected {
 				bufferFailure(t, output, tt.expected)
 			}

--- a/test/newline_test.go
+++ b/test/newline_test.go
@@ -20,47 +20,47 @@ func TestNewline(t *testing.T) {
 		{
 			name:     "Minimal spacing + <br> line break + standard middle paragraph",
 			input:    []string{"- First item", "\t- Sub item 1", "\t- Sub item 2", "- Second item", "# Heading 1", "Paragraph text", "that spans two lines.", "", "New paragraph.", "# Header 1", "__*Fancy*__ paragraph<br>", "with a ~~line break~~."},
-			expected: "• First item\n    • Sub item 1\n    • Sub item 2\n• Second item\n\n\033[1m─Heading 1─\033[0m\nParagraph text that spans two lines. \n\nNew paragraph. \n\n\033[1m─Header 1─\033[0m\n\033[1m\033[3mFancy\033[0m\033[0m paragraph\nwith a \033[9mline break\033[0m. ",
+			expected: "• First item\n    • Sub item 1\n    • Sub item 2\n• Second item\n\n\033[1m─Heading 1─\033[0m\nParagraph text that spans two lines.\n\nNew paragraph.\n\n\033[1m─Header 1─\033[0m\n\033[1m\033[3mFancy\033[0m\033[0m paragraph\nwith a \033[9mline break\033[0m.",
 		},
 		{
 			name:     "Standard spacing + double-space line break + emphasized middle paragraph",
 			input:    []string{"- First item", "\t- Sub item 1", "\t- Sub item 2", "- Second item", "", "# Heading 1", "Paragraph text", "that spans two lines.", "", "*New* paragraph.", "", "# Header 1", "__*Fancy*__ paragraph  ", "with a ~~line break~~."},
-			expected: "• First item\n    • Sub item 1\n    • Sub item 2\n• Second item\n\n\033[1m─Heading 1─\033[0m\nParagraph text that spans two lines. \n\n\033[3mNew\033[0m paragraph. \n\n\033[1m─Header 1─\033[0m\n\033[1m\033[3mFancy\033[0m\033[0m paragraph\nwith a \033[9mline break\033[0m. ",
+			expected: "• First item\n    • Sub item 1\n    • Sub item 2\n• Second item\n\n\033[1m─Heading 1─\033[0m\nParagraph text that spans two lines.\n\n\033[3mNew\033[0m paragraph.\n\n\033[1m─Header 1─\033[0m\n\033[1m\033[3mFancy\033[0m\033[0m paragraph\nwith a \033[9mline break\033[0m.",
 		},
 		{
 			name:     "Exaggerated spacing + double-space line break + standard middle paragraph",
 			input:    []string{"- First item", "\t- Sub item 1", "\t- Sub item 2", "- Second item", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "# Heading 1", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "Paragraph text", "that spans two lines.", "", "New paragraph.", "", "", "", "", "", "", "", "# Header 1", "__*Fancy*__ paragraph  ", "with a ~~line break~~."},
-			expected: "• First item\n    • Sub item 1\n    • Sub item 2\n• Second item\n\n\033[1m─Heading 1─\033[0m\nParagraph text that spans two lines. \n\nNew paragraph. \n\n\033[1m─Header 1─\033[0m\n\033[1m\033[3mFancy\033[0m\033[0m paragraph\nwith a \033[9mline break\033[0m. ",
+			expected: "• First item\n    • Sub item 1\n    • Sub item 2\n• Second item\n\n\033[1m─Heading 1─\033[0m\nParagraph text that spans two lines.\n\nNew paragraph.\n\n\033[1m─Header 1─\033[0m\n\033[1m\033[3mFancy\033[0m\033[0m paragraph\nwith a \033[9mline break\033[0m.",
 		},
 		{
 			name:     "Paragraph followed by list (minimal spacing)",
 			input:    []string{"This is a happy little paragraph", "- First item", "- Second item", "\t- Sub item 1", "- Third item"},
-			expected: "This is a happy little paragraph \n• First item\n• Second item\n    • Sub item 1\n• Third item\n",
+			expected: "This is a happy little paragraph\n• First item\n• Second item\n    • Sub item 1\n• Third item\n",
 		},
 		{
 			name:     "Paragraph followed by list (standard spacing)",
 			input:    []string{"This is a happy little paragraph", "", "- First item", "- Second item", "\t- Sub item 1", "- Third item"},
-			expected: "This is a happy little paragraph \n• First item\n• Second item\n    • Sub item 1\n• Third item\n",
+			expected: "This is a happy little paragraph\n• First item\n• Second item\n    • Sub item 1\n• Third item\n",
 		},
 		{
 			name:     "Paragraph followed by list (exaggerated spacing)",
 			input:    []string{"This is a happy little paragraph", "", "", "", "", "", "", "", "", "- First item", "- Second item", "\t- Sub item 1", "- Third item"},
-			expected: "This is a happy little paragraph \n• First item\n• Second item\n    • Sub item 1\n• Third item\n",
+			expected: "This is a happy little paragraph\n• First item\n• Second item\n    • Sub item 1\n• Third item\n",
 		},
 		{
 			name:     "List followed by a paragraph (minimal spacing)",
 			input:    []string{"- First item", "- Second item", "\t- Sub item 1", "- Third item", "This is a happy little paragraph"},
-			expected: "• First item\n• Second item\n    • Sub item 1\n• Third item\n\nThis is a happy little paragraph ",
+			expected: "• First item\n• Second item\n    • Sub item 1\n• Third item\n\nThis is a happy little paragraph",
 		},
 		{
 			name:     "List followed by a paragraph (standard spacing)",
 			input:    []string{"- First item", "- Second item", "\t- Sub item 1", "- Third item", "", "This is a happy little paragraph"},
-			expected: "• First item\n• Second item\n    • Sub item 1\n• Third item\n\nThis is a happy little paragraph ",
+			expected: "• First item\n• Second item\n    • Sub item 1\n• Third item\n\nThis is a happy little paragraph",
 		},
 		{
 			name:     "List followed by a paragraph (exaggerated spacing)",
 			input:    []string{"- First item", "- Second item", "\t- Sub item 1", "- Third item", "", "", "", "", "", "", "", "", "This is a happy little paragraph"},
-			expected: "• First item\n• Second item\n    • Sub item 1\n• Third item\n\nThis is a happy little paragraph ",
+			expected: "• First item\n• Second item\n    • Sub item 1\n• Third item\n\nThis is a happy little paragraph",
 		},
 		{
 			name:     "Multiple HRs",
@@ -70,17 +70,17 @@ func TestNewline(t *testing.T) {
 		{
 			name:     "HR after paragraph",
 			input:    []string{"This is a paragraph.", "---"},
-			expected: "This is a paragraph. \n\n" + strings.Repeat("─", width) + "\n\n",
+			expected: "This is a paragraph.\n\n" + strings.Repeat("─", width) + "\n\n",
 		},
 		{
 			name:     "Paragraph after HR",
 			input:    []string{"---", "This is a paragraph."},
-			expected: strings.Repeat("─", width) + "\n\n" + "This is a paragraph. ",
+			expected: strings.Repeat("─", width) + "\n\n" + "This is a paragraph.",
 		},
 		{
 			name:     "Paragraph after HR (w/blank lines)",
 			input:    []string{"---", "", "", "This is a paragraph."},
-			expected: strings.Repeat("─", width) + "\n\n" + "This is a paragraph. ",
+			expected: strings.Repeat("─", width) + "\n\n" + "This is a paragraph.",
 		},
 		{
 			name:     "HR after header",

--- a/test/newline_test.go
+++ b/test/newline_test.go
@@ -35,14 +35,14 @@ func TestNewline(t *testing.T) {
 			expected: "This is a happy little paragraph\n• First item\n• Second item\n    • Sub item 1\n• Third item\n",
 		},
 		{
-			name:     "Paragraph followed by list (standard spacing)",
+			name:     "Paragraph followed by list (standard spacing; the empty line should be preserved in this case)",
 			input:    []string{"This is a happy little paragraph", "", "- First item", "- Second item", "\t- Sub item 1", "- Third item"},
-			expected: "This is a happy little paragraph\n• First item\n• Second item\n    • Sub item 1\n• Third item\n",
+			expected: "This is a happy little paragraph\n\n• First item\n• Second item\n    • Sub item 1\n• Third item\n",
 		},
 		{
-			name:     "Paragraph followed by list (exaggerated spacing)",
+			name:     "Paragraph followed by list (exaggerated spacing; one empty line should be preserved in this case)",
 			input:    []string{"This is a happy little paragraph", "", "", "", "", "", "", "", "", "- First item", "- Second item", "\t- Sub item 1", "- Third item"},
-			expected: "This is a happy little paragraph\n• First item\n• Second item\n    • Sub item 1\n• Third item\n",
+			expected: "This is a happy little paragraph\n\n• First item\n• Second item\n    • Sub item 1\n• Third item\n",
 		},
 		{
 			name:     "List followed by a paragraph (minimal spacing)",

--- a/test/strikethrough_test.go
+++ b/test/strikethrough_test.go
@@ -16,52 +16,52 @@ func TestRenderStrikethroughText(t *testing.T) {
 		{
 			name:     "Strikethrough text using double tildes",
 			input:    []string{"~~strikethrough~~"},
-			expected: "\033[9mstrikethrough\033[0m ",
+			expected: "\033[9mstrikethrough\033[0m",
 		},
 		// Strikethrough within a sentence
 		{
 			name:     "Strikethrough in the middle of sentence",
 			input:    []string{"A sentence with ~~strikethrough~~ in the middle."},
-			expected: "A sentence with \033[9mstrikethrough\033[0m in the middle. ",
+			expected: "A sentence with \033[9mstrikethrough\033[0m in the middle.",
 		},
 		{
 			name:     "Strikethrough at the start and end of sentence",
 			input:    []string{"~~Strikethrough~~ at the start, and at the ~~end~~"},
-			expected: "\033[9mStrikethrough\033[0m at the start, and at the \033[9mend\033[0m ",
+			expected: "\033[9mStrikethrough\033[0m at the start, and at the \033[9mend\033[0m",
 		},
 		{
 			name:     "Multiple strikethrough segments in one line (not at start or end)",
 			input:    []string{"This is ~~strikethrough1~~, and this is ~~strikethrough2~~ as well."},
-			expected: "This is \033[9mstrikethrough1\033[0m, and this is \033[9mstrikethrough2\033[0m as well. ",
+			expected: "This is \033[9mstrikethrough1\033[0m, and this is \033[9mstrikethrough2\033[0m as well.",
 		},
 		// Edge cases
 		{
 			name:     "Strikethrough with incomplete tildes (should render paragraph)",
 			input:    []string{"This is ~not fully strikethrough~~ text."},
-			expected: "This is ~not fully strikethrough~~ text. ",
+			expected: "This is ~not fully strikethrough~~ text.",
 		},
 		// Nested strikethrough with other formatting (italic/bold)
 		{
 			name:     "Strikethrough nested inside italic",
 			input:    []string{"This is _italic ~~and strikethrough~~ inside_."},
-			expected: "This is \033[3mitalic \033[9mand strikethrough\033[0m inside\033[0m. ",
+			expected: "This is \033[3mitalic \033[9mand strikethrough\033[0m inside\033[0m.",
 		},
 		{
 			name:     "Strikethrough nested inside bold",
 			input:    []string{"This is __bold ~~and strikethrough~~ inside__."},
-			expected: "This is \033[1mbold \033[9mand strikethrough\033[0m inside\033[0m. ",
+			expected: "This is \033[1mbold \033[9mand strikethrough\033[0m inside\033[0m.",
 		},
 		// Strikethrough with special characters
 		{
 			name:     "Strikethrough with special characters",
 			input:    []string{"This is ~~strikethrough & special <chars>~~ text."},
-			expected: "This is \033[9mstrikethrough & special <chars>\033[0m text. ",
+			expected: "This is \033[9mstrikethrough & special <chars>\033[0m text.",
 		},
 		// Strikethrough tilde
 		{
 			name:     "Strikethrough tilde",
 			input:    []string{"Strikethrough tildes (~~~~~) should be possible."},
-			expected: "Strikethrough tildes (\033[9m~\033[0m) should be possible. ",
+			expected: "Strikethrough tildes (\033[9m~\033[0m) should be possible.",
 		},
 	}
 

--- a/test/strikethrough_test.go
+++ b/test/strikethrough_test.go
@@ -67,7 +67,7 @@ func TestRenderStrikethroughText(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			output := bean.RenderMarkdown(tt.input)
+			output := bean.RenderMarkdown(tt.input, terminalWidth)
 			if output != tt.expected {
 				bufferFailure(t, output, tt.expected)
 			}

--- a/test/wrap_test.go
+++ b/test/wrap_test.go
@@ -68,6 +68,11 @@ func TestTextWrapping(t *testing.T) {
 			input:    []string{"This is a fairly long paragraph that was input by  ", "the user and should be wrapped uniquely since the manual break occurs before the terminal width."},
 			expected: "This is a fairly long paragraph that was input by\nthe user and should be wrapped uniquely since the manual break occurs before the\nterminal width.",
 		},
+		{
+			name:     "Mixed list w/long items that should wrap",
+			input:    []string{"- First item", "\t1. Sub item 1", "\t2. Sub item 2 is really quite long gee I wonder if this will wrap correctly to the next line it sure would be nice if it did", "- Second item is also really long to prove that unindented list items can also wrap in the same way as indented ones"},
+			expected: "• First item\n    1. Sub item 1\n    2. Sub item 2\n• Second item\n",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/test/wrap_test.go
+++ b/test/wrap_test.go
@@ -1,0 +1,80 @@
+package test
+
+import (
+	"testing"
+
+	bean "github.com/Trojan2021/BEAN/render"
+)
+
+func TestTextWrapping(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []string
+		expected string
+	}{
+		// Text/Word Wrapping Testing
+		{
+			name:     "Single-line paragraph (should wrap once)",
+			input:    []string{"This is a fairly long paragraph that was input by the user in a single line and will likely need to be wrapped."},
+			expected: "This is a fairly long paragraph that was input by the user in a single line and\nwill likely need to be wrapped.",
+		},
+		{
+			name:     "Multi-line paragraph (should wrap once)",
+			input:    []string{"This is a fairly long paragraph", "that was input by the user in two separate lines and will likely need to be wrapped."},
+			expected: "This is a fairly long paragraph that was input by the user in two separate lines\nand will likely need to be wrapped.",
+		},
+		{
+			name:     "Single-line paragraph (should wrap twice)",
+			input:    []string{"This is a fairly long paragraph that was input by the user in a single line and will likely need to be wrapped. It is longer than the last one and as such it should be wrapped twice."},
+			expected: "This is a fairly long paragraph that was input by the user in a single line and\nwill likely need to be wrapped. It is longer than the last one and as such it\nshould be wrapped twice.",
+		},
+		{
+			name:     "Multi-line paragraph (should wrap twice)",
+			input:    []string{"This is a fairly long paragraph", "that was input by the user in two separate lines and will likely need to be wrapped.", "It is longer than the last one and as such it should be wrapped twice."},
+			expected: "This is a fairly long paragraph that was input by the user in two separate lines\nand will likely need to be wrapped. It is longer than the last one and as such\nit should be wrapped twice.",
+		},
+		{
+			name:     "Single-line paragraph w/bold text across lines (should wrap once)",
+			input:    []string{"This is a fairly long paragraph that was input by the user in a single **line and will likely need to be** wrapped."},
+			expected: "This is a fairly long paragraph that was input by the user in a single \033[1mline and\nwill likely need to be\033[0m wrapped.",
+		},
+		{
+			name:     "Single-line paragraph w/italic text across lines (should wrap once)",
+			input:    []string{"This is a fairly long paragraph that was input by the user in a single *line and will likely need to be* wrapped."},
+			expected: "This is a fairly long paragraph that was input by the user in a single \033[3mline and\nwill likely need to be\033[0m wrapped.",
+		},
+		{
+			name:     "Single-line paragraph w/strikethrough text across lines (should wrap once)",
+			input:    []string{"This is a fairly long paragraph that was input by the user in a single ~~line and will likely need to be~~ wrapped."},
+			expected: "This is a fairly long paragraph that was input by the user in a single \033[9mline and\nwill likely need to be\033[0m wrapped.",
+		},
+		{
+			name:     "Single-line paragraph w/inline code across lines (should wrap once)",
+			input:    []string{"This is a fairly long paragraph that was input by the user in a single `line and will likely need to be` wrapped."},
+			expected: "This is a fairly long paragraph that was input by the user in a single \033[48;5;238;38;5;1mline and\nwill likely need to be\033[0m wrapped.",
+		},
+		{
+			name:     "Single-line paragraph w/o spaces (should wrap once)",
+			input:    []string{"Thisisafairlylongparagraphthatwasinputbytheuserinasinglelinewithoutanyspacesandwilllikelyneedtobewrapped."},
+			expected: "Thisisafairlylongparagraphthatwasinputbytheuserinasinglelinewithoutanyspacesandw\nilllikelyneedtobewrapped.",
+		},
+		{
+			name:     "Paragraph w/manual break via <br> (should wrap once)",
+			input:    []string{"This is a fairly long paragraph that was input by<br>", "the user and should be wrapped uniquely since the manual break occurs before the terminal width."},
+			expected: "This is a fairly long paragraph that was input by\nthe user and should be wrapped uniquely since the manual break occurs before the\nterminal width.",
+		},
+		{
+			name:     "Paragraph w/manual break via double space (should wrap once)",
+			input:    []string{"This is a fairly long paragraph that was input by  ", "the user and should be wrapped uniquely since the manual break occurs before the terminal width."},
+			expected: "This is a fairly long paragraph that was input by\nthe user and should be wrapped uniquely since the manual break occurs before the\nterminal width.",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			output := bean.RenderMarkdown(tt.input, terminalWidth)
+			if output != tt.expected {
+				bufferFailure(t, output, tt.expected)
+			}
+		})
+	}
+}

--- a/test/wrap_test.go
+++ b/test/wrap_test.go
@@ -71,7 +71,7 @@ func TestTextWrapping(t *testing.T) {
 		{
 			name:     "Mixed list w/long items that should wrap",
 			input:    []string{"- First item", "\t1. Sub item 1", "\t2. Sub item 2 is really quite long gee I wonder if this will wrap correctly to the next line it sure would be nice if it did", "- Second item is also really long to prove that unindented list items can also wrap in the same way as indented ones"},
-			expected: "• First item\n    1. Sub item 1\n    2. Sub item 2\n• Second item\n",
+			expected: "• First item\n    1. Sub item 1\n    2. Sub item 2 is really quite long gee I wonder if this will wrap correctly\n      to the next line it sure would be nice if it did\n• Second item is also really long to prove that unindented list items can also\n  wrap in the same way as indented ones\n",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
This merge adds support for wrapping based on words (or based on a pure length limit if no words are found) within paragraphs and lists.

The relevant tests were added and many previous tests were updated to account for the new paragraph rendering.